### PR TITLE
Factor out file parsing.

### DIFF
--- a/crates/turborepo-lib/src/files/README.md
+++ b/crates/turborepo-lib/src/files/README.md
@@ -1,0 +1,19 @@
+# Special File Types
+
+There are a few files that we'll need to read regularly, so we combine their interfaces here.
+
+## Default Values
+
+Each of these structs implements per-field defaults without `Option<>` as long as we do not need to distinguish between "set" and "unset". For example, these two `package.json` files are materially different per business logic, and as such are implemented as `Option<Workspaces>` instead of just defaulting to an empty `Workspaces::TopLevel(vec![])`.
+
+```json
+{
+  "workspaces": []
+}
+```
+
+```json
+{}
+```
+
+Note that "enabling serialized output to be only of user-supplied values" _is_ a need to distinguish between "set" and "unset".

--- a/crates/turborepo-lib/src/files/mod.rs
+++ b/crates/turborepo-lib/src/files/mod.rs
@@ -1,0 +1,4 @@
+pub(crate) mod package_json;
+pub(crate) mod pnpm_workspace;
+pub(crate) mod turbo_json;
+pub(crate) mod yarn_rc;

--- a/crates/turborepo-lib/src/files/package_json.rs
+++ b/crates/turborepo-lib/src/files/package_json.rs
@@ -1,0 +1,68 @@
+use std::{fs, path::PathBuf};
+
+use anyhow::Result;
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PackageJson {
+    pub version: Option<String>,
+    pub workspaces: Option<Workspaces>,
+}
+
+#[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Clone)]
+#[serde(untagged)]
+pub enum Workspaces {
+    TopLevel(Vec<String>),
+
+    // This only works in old npm.
+    Nested { packages: Vec<String> },
+}
+
+impl AsRef<[String]> for Workspaces {
+    fn as_ref(&self) -> &[String] {
+        match self {
+            Workspaces::TopLevel(packages) => packages.as_slice(),
+            Workspaces::Nested { packages } => packages.as_slice(),
+        }
+    }
+}
+
+impl From<Workspaces> for Vec<String> {
+    fn from(value: Workspaces) -> Self {
+        match value {
+            Workspaces::TopLevel(packages) => packages,
+            Workspaces::Nested { packages } => packages,
+        }
+    }
+}
+
+impl Default for PackageJson {
+    fn default() -> Self {
+        Self {
+            version: None,
+            workspaces: Some(Workspaces::TopLevel(vec![])),
+        }
+    }
+}
+
+pub fn read(path: PathBuf) -> Result<PackageJson> {
+    let package_json_string = fs::read_to_string(path)?;
+    let package_json = serde_json::from_str(&package_json_string)?;
+
+    Ok(package_json)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_nested_workspace_globs() -> Result<()> {
+        let top_level: PackageJson = serde_json::from_str("{ \"workspaces\": [\"packages/**\"]}")?;
+        assert_eq!(top_level.workspaces.unwrap().as_ref(), vec!["packages/**"]);
+        let nested: PackageJson =
+            serde_json::from_str("{ \"workspaces\": {\"packages\": [\"packages/**\"]}}")?;
+        assert_eq!(nested.workspaces.unwrap().as_ref(), vec!["packages/**"]);
+        Ok(())
+    }
+}

--- a/crates/turborepo-lib/src/files/pnpm_workspace.rs
+++ b/crates/turborepo-lib/src/files/pnpm_workspace.rs
@@ -1,0 +1,16 @@
+use std::{fs, path::PathBuf};
+
+use anyhow::Result;
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Default, Clone, Serialize, Deserialize)]
+pub struct PnpmWorkspace {
+    pub packages: Option<Vec<String>>,
+}
+
+pub fn read(path: PathBuf) -> Result<PnpmWorkspace> {
+    let pnpm_workspace_string = fs::read_to_string(path)?;
+    let pnpm_workspace = serde_yaml::from_str(&pnpm_workspace_string)?;
+
+    Ok(pnpm_workspace)
+}

--- a/crates/turborepo-lib/src/files/turbo_json.rs
+++ b/crates/turborepo-lib/src/files/turbo_json.rs
@@ -1,0 +1,37 @@
+use std::{fs, path::PathBuf};
+
+use anyhow::Result;
+use semver::{Version, VersionReq};
+use serde::{Deserialize, Serialize};
+
+#[derive(Serialize, Deserialize, Debug)]
+#[serde(default, rename_all = "camelCase")]
+pub struct TurboJson {
+    pub turbo_version: String,
+}
+
+impl TurboJson {
+    #[allow(dead_code)]
+    pub fn check_version(&self, version: &str) -> Result<bool> {
+        let version = Version::parse(version)?;
+
+        let version_request = VersionReq::parse(&self.turbo_version)?;
+        Ok(version_request.matches(&version))
+    }
+}
+
+impl Default for TurboJson {
+    fn default() -> Self {
+        Self {
+            turbo_version: "*".to_string(),
+        }
+    }
+}
+
+#[allow(dead_code)]
+pub fn read(path: PathBuf) -> Result<TurboJson> {
+    let turbo_json_string = fs::read_to_string(path)?;
+    let turbo_json = serde_json::from_str(&turbo_json_string)?;
+
+    Ok(turbo_json)
+}

--- a/crates/turborepo-lib/src/files/yarn_rc.rs
+++ b/crates/turborepo-lib/src/files/yarn_rc.rs
@@ -1,0 +1,25 @@
+use std::{fs, path::PathBuf};
+
+use anyhow::Result;
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(default, rename_all = "camelCase")]
+pub struct YarnRc {
+    pub pnp_unplugged_folder: PathBuf,
+}
+
+impl Default for YarnRc {
+    fn default() -> Self {
+        Self {
+            pnp_unplugged_folder: [".yarn", "unplugged"].iter().collect(),
+        }
+    }
+}
+
+pub fn read(path: PathBuf) -> Result<YarnRc> {
+    let yarn_rc_string = fs::read_to_string(path)?;
+    let yarn_rc = serde_yaml::from_str(&yarn_rc_string)?;
+
+    Ok(yarn_rc)
+}

--- a/crates/turborepo-lib/src/lib.rs
+++ b/crates/turborepo-lib/src/lib.rs
@@ -2,6 +2,7 @@ mod cli;
 mod client;
 mod commands;
 mod config;
+mod files;
 mod package_manager;
 mod retry;
 mod shim;


### PR DESCRIPTION
(This will need retargeting, but the diff is in the same state it will be at the end.)

`shim.rs` is getting absurdly long and unwieldy. We need to get to a better-factored state; starting by splitting out all of the definitions for files that we parse into a more-organized home.